### PR TITLE
deps and pyup: use own requirements file for fork-specific packages

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -2,3 +2,13 @@
 # see https://pyup.io/docs/configuration/ for all available options
 
 schedule: "every week on monday"
+
+requirements:
+  - requirements/fork.txt:
+      update: all
+  - requirements/base.txt:
+      update: False
+  - requirements/dev.txt:
+      update: False
+  - requirements/prod.txt:
+      update: False

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,6 @@ django-capture-tag==1.0
 django-cloudflare-push==0.2.1
 django_csp==3.7
 django-parler==2.3
-djangosaml2==0.40.0
 sentry-sdk==1.5.3
 wagtail==2.15.2
 whitenoise==5.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 -r base.txt
+-r fork.txt
 django-debug-toolbar==3.2.4
 factory-boy==3.2.1
 Faker==11.3.0

--- a/requirements/fork.txt
+++ b/requirements/fork.txt
@@ -1,0 +1,2 @@
+# requirements needed in this fork, but not a+
+djangosaml2==0.40.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,3 @@
 -r base.txt
+-r fork.txt
 gunicorn==20.1.0


### PR DESCRIPTION
This should work, right? 
We can make use of the overview of pyup while only updating the fork-specific packages and doing the others with the rebase on a+.