### PR TITLE
apps/djangosaml2_overwrites: add account logout view to allowed urls …

### DIFF
--- a/apps/djangosaml2_overwrites/middlewares.py
+++ b/apps/djangosaml2_overwrites/middlewares.py
@@ -13,21 +13,21 @@ class SamlSignupMiddleware:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if request.user.is_authenticated:
-            email = EmailAddress.objects.get(user=request.user,
-                                             email=request.user.email)
+            email = EmailAddress.objects.get(
+                user=request.user, email=request.user.email
+            )
             if not email.verified:
                 path = request.path
                 view = request.resolver_match.view_name
 
                 allowed_paths = [
-                    reverse('saml2_signup'),
-                    reverse('saml2_logout'),
-                    reverse('set_language'),
-                    reverse('javascript-catalog')
+                    reverse("account_logout"),
+                    reverse("saml2_signup"),
+                    reverse("saml2_logout"),
+                    reverse("set_language"),
+                    reverse("javascript-catalog"),
                 ]
-                allowed_views = [
-                    'wagtail_serve'
-                ]
+                allowed_views = ["wagtail_serve"]
 
                 if path not in allowed_paths and view not in allowed_views:
-                    return redirect(reverse('saml2_signup') + "?next=" + path)
+                    return redirect(reverse("saml2_signup") + "?next=" + path)

--- a/changelog/_1112.md
+++ b/changelog/_1112.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- add account logout view to allowed urls during saml signup. Fixes aborting
+  the saml signup not being possible (#6).


### PR DESCRIPTION
…during saml signup to allow aborting the signup

fixes #6

Testing: when logging in via SSO for the first time, you are asked to enter your username. Previously, clicking logout would take you back to the signup screen and it was impossible to cancel it. Clicking logout now correctly logs you out

(Note: with docker installed, run `make saml-server` to run a test saml server, login with username: user1 pw:user1pass, you will probably get an error, reload the page and log in a second time)

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
